### PR TITLE
Use wait_until_ready

### DIFF
--- a/LinuxBoi-testing.py
+++ b/LinuxBoi-testing.py
@@ -60,6 +60,7 @@ class LinuxBoiTesting(commands.AutoShardedBot):
 
         self.load_extension('jishaku')
         self.remove_command('help')
+        self.loop.create_task(self.ready())
 
     async def on_connect(self):
         os.system("clear")
@@ -81,7 +82,8 @@ class LinuxBoiTesting(commands.AutoShardedBot):
 
         self.db.commit()
 
-    async def on_ready(self):
+    async def ready(self):
+        await self.wait_until_ready()
         os.system("clear")
 
         get_activity = self.cursor.execute("SELECT rowid, * FROM bot_information")

--- a/LinuxBoi.py
+++ b/LinuxBoi.py
@@ -60,6 +60,7 @@ class LinuxBoi(commands.AutoShardedBot):
 
         self.load_extension('jishaku')
         self.remove_command('help')
+        self.loop.create_task(self.ready())
 
     async def on_connect(self):
         os.system("clear")
@@ -81,7 +82,8 @@ class LinuxBoi(commands.AutoShardedBot):
 
         self.db.commit()
 
-    async def on_ready(self):
+    async def ready(self):
+        await self.wait_until_ready()
         os.system("clear")
 
         get_activity = self.cursor.execute("SELECT rowid, * FROM bot_information")


### PR DESCRIPTION
Hey there! I noticed that you're doing some pretty important stuff `on_ready()`. This can sometimes get problematic because `on_ready()` can't be relied on to be called only once when the bot starts up and in rare cases cause the bot to disconnect. To avoid this, I've suggested using `wait_until_ready()` in order to achieve the same effect without the side-effects of `on_ready()`